### PR TITLE
support koa ctx.state

### DIFF
--- a/lib/koa.js
+++ b/lib/koa.js
@@ -11,6 +11,21 @@ function xtplRender(path, data, option) {
     };
 }
 
+/**
+ * merge source to target
+ *
+ * @param {Object} target
+ * @param {Object} source
+ * @return {Object}
+ * @api private
+ */
+function merge(target, source) {
+  for (var key in source) {
+    target[key] = source[key];
+  }
+}
+
+
 // option.views
 // option.extname
 // option.
@@ -19,6 +34,10 @@ module.exports = function (app, option) {
     var extname = option.extname || 'xtpl';
 
     function *render(path, data, opt) {
+
+        // merge koa ctx.state
+        merge(data, this.state);
+
         var html = yield xtplRender(Path.resolve(views, path + '.' + extname), data, option);
         if (!opt || opt.write !== false) {
             this.type = 'html';

--- a/lib/koa.js
+++ b/lib/koa.js
@@ -35,10 +35,13 @@ module.exports = function (app, option) {
 
     function *render(path, data, opt) {
 
-        // merge koa ctx.state
-        merge(data, this.state);
+        var context = {};
 
-        var html = yield xtplRender(Path.resolve(views, path + '.' + extname), data, option);
+        // merge koa ctx.state, notice: koa < 0.14.0 have no ctx.state
+        merge(context, this.state);
+        merge(context, data);
+
+        var html = yield xtplRender(Path.resolve(views, path + '.' + extname), context, option);
         if (!opt || opt.write !== false) {
             this.type = 'html';
             this.body = html;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "expect.js": "^0.3.1",
     "express": "~3.4.8",
     "istanbul": "~0.2.10",
-    "koa": "^0.11.0",
+    "koa": "^0.21.0",
     "mocha": "~1.19.0",
     "mocha-istanbul": "~0.2.0",
     "request": "^2.42.0",

--- a/tests/fixture/main.xtpl
+++ b/tests/fixture/main.xtpl
@@ -1,1 +1,1 @@
-{{{y}}}{{include('./part.xtpl')}}
+{{{y}}}{{include('./part.xtpl')}}{{name}}{{age}}

--- a/tests/specs/index.js
+++ b/tests/specs/index.js
@@ -61,17 +61,23 @@ describe('xtpl', function () {
             views: path.resolve(__dirname, '../fixture/')
         });
         app.use(function *() {
+
+            // test for ctx.state
+            this.state.name = 'foo';
+            this.state.age = 18;
+
             var html = yield* this.render('main', {
                 y: '<',
-                x: '>'
+                x: '>',
+                age: 20
             });
-            expect(html).to.be('<&gt;');
+            expect(html).to.be('<&gt;foo20');
         });
-        app.listen(9000);
+        app.listen(4001);
         var request = require('request');
         setTimeout(function () {
-            request({url: 'http://localhost:9000'}, function (error, response, body) {
-                expect(body).to.be('<&gt;');
+            request({url: 'http://localhost:4001'}, function (error, response, body) {
+                expect(body).to.be('<&gt;foo20');
                 done();
             });
         }, 100);


### PR DESCRIPTION

koa 文档：

```
ctx.state

The recommended namespace for passing information through middleware and to your frontend views.
```

类似 express 的 locals, 可以在 view 里直接使用的变量，如 user, 而无需每次 render 的时候都需要传入。
